### PR TITLE
Fix hero image

### DIFF
--- a/src/app/pages/page/page.component.ts
+++ b/src/app/pages/page/page.component.ts
@@ -27,8 +27,7 @@ export class PageComponent implements OnInit {
   setBackground() {
     if (this.page.banner) {
       const styles: Object = {
-        background: `url(${this.page.banner}) no-repeat center center`,
-        'background-size': 'cover'
+        background: `url(${this.page.banner}) center center / cover no-repeat`
       };
       return styles;
     } else {


### PR DESCRIPTION
When navigating to a page, then to another one and back to the first, the hero image doesn't have the cover attribute anymore. Setting everything in one property fixes it.